### PR TITLE
Removing name attributes as this conflicts with rjs advice

### DIFF
--- a/app/assets/javascripts/common_form.js
+++ b/app/assets/javascripts/common_form.js
@@ -37,7 +37,7 @@ function create_subscription (recurring) {
     "city" : $('input[name="city"]').val(),
     "state" : $('#state').val(),
     "zip": $('input[name="postal-code"]').val(),
-    "number": $('input[name="number"]').val(),
+    "number": $('input[data-recurly="number"]').val(),
     "month": $('input[name="month"]').val(),
     "year": $('input[name="year"]').val(),
     "routing_number": $('input[name="routing-number"]').val(),

--- a/app/views/minimal.slim
+++ b/app/views/minimal.slim
@@ -58,7 +58,7 @@ body
       .row.customer-fields--card-number
         .form-input.form-input__number
           label for="number" Credit Card Number
-          input type="text" data-recurly="number" id="number" name="number" class="form-input__required"
+          input type="text" data-recurly="number" id="number" class="form-input__required"
           span.icon.icon-card.icon-card__generic
           span.icon.icon-lock
 
@@ -70,7 +70,7 @@ body
 
         .form-input.customer-fields--card-cvv.form-input__cvv
           label for="cvv" CVV
-          input type="text" data-recurly="cvv" id="cvv" name="cvv" maxlength="4" class="form-input__required"
+          input type="text" data-recurly="cvv" id="cvv" maxlength="4" class="form-input__required"
 
         .form-input.customer-fields--card-postal-code.form-input__postal_code
           label for="postal_code" Zip Code

--- a/app/views/more.slim
+++ b/app/views/more.slim
@@ -55,7 +55,7 @@ body
       .row.customer-fields--card-number
         .form-input.form-input__number
           label for="number" Credit Card Number
-          input type="text" data-recurly="number" id="number" name="number"
+          input type="text" data-recurly="number" id="number"
           span.icon.icon-card.icon-card__generic
           span.icon.icon-lock
 
@@ -67,7 +67,7 @@ body
 
         .form-input.customer-fields--card-cvv.form-input__cvv
           label for="cvv" CVC
-          input type="text" data-recurly="cvv" id="cvv" name="cvv" maxlength="4"
+          input type="text" data-recurly="cvv" id="cvv" maxlength="4"
 
       .row.customer-fields--address
         .form-input

--- a/app/views/one_time.slim
+++ b/app/views/one_time.slim
@@ -58,7 +58,7 @@ body
       .row.customer-fields--card-number
         .form-input.form-input__number
           label for="number" Credit Card Number
-          input type="text" data-recurly="number" id="number" name="number"
+          input type="text" data-recurly="number" id="number"
           span.icon.icon-card.icon-card__generic
           span.icon.icon-lock
 
@@ -70,7 +70,7 @@ body
 
         .form-input.customer-fields--card-cvv.form-input__cvv
           label for="cvv" CVC
-          input type="text" data-recurly="cvv" id="cvv" name="cvv" maxlength="4"
+          input type="text" data-recurly="cvv" id="cvv" maxlength="4"
 
       == partial(:'shared/one_time/address_info')
 

--- a/app/views/shared/advanced_form/billing_info.slim
+++ b/app/views/shared/advanced_form/billing_info.slim
@@ -23,7 +23,7 @@ section.billing-info-container.hide-form-onsuccess
     .panel.card
       .row.customer-fields--card-number
         .form-input.form-input__number
-          input type="text" data-recurly="number" id="number" name="number" class="form-input__required" placeholder="4111 1111 1111 1111"
+          input type="text" data-recurly="number" id="number" class="form-input__required" placeholder="4111 1111 1111 1111"
           span.icon.icon-card.icon-card__generic
           span.icon.icon-lock
 
@@ -33,7 +33,7 @@ section.billing-info-container.hide-form-onsuccess
             input type="text" data-recurly="year" id="year" name="year" placeholder="YY" maxlength="2" class="form-input__required"
 
         .form-input.customer-fields--card-cvv.form-input__cvv
-          input type="text" data-recurly="cvv" id="cvv" name="cvv" class="form-input__required" placeholder="CVV"
+          input type="text" data-recurly="cvv" id="cvv" class="form-input__required" placeholder="CVV"
 
     .panel.bank-account
       == partial(:'shared/bank_account/input_fields_with_placeholders')

--- a/app/views/update_billing.slim
+++ b/app/views/update_billing.slim
@@ -55,7 +55,7 @@ body
       .row.customer-fields--card-number
         .form-input.form-input__number
           label for="number" Credit Card Number
-          input type="text" data-recurly="number" id="number" name="number"
+          input type="text" data-recurly="number" id="number"
           span.icon.icon-card.icon-card__generic
           span.icon.icon-lock
 
@@ -67,7 +67,7 @@ body
 
         .form-input.customer-fields--card-cvv.form-input__cvv
           label for="cvv" CVC
-          input type="text" data-recurly="cvv" id="cvv" name="cvv" maxlength="4"
+          input type="text" data-recurly="cvv" id="cvv" maxlength="4"
 
       .row.customer-fields--address
         .form-input


### PR DESCRIPTION
Removing name attributes for cvv and number inputs as this conflicts with what is recommended in the rjs docs.